### PR TITLE
docs: standardize behavior spelling and fix lint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Mobile-first V60 timer with multiple recipes, pour-based running weight targets,
 - **Finish celebration** overlay (✓ badge + confetti) with ARIA live announcement.
 - **Accessibility & UX:** WCAG AA on light cards, ≥44px tap targets, mobile-first layout.
 
-## Controls & Behaviours
+## Controls & Behaviors
 - **Prev:** Jump to start of previous step (updates targets immediately).
 - **Start/Pause:** Toggle the timer.
 - **Skip:** Jump to end of current step (immediate transition, chime, and target update).
 - **Reset:** Pause, set elapsed to 0, hide celebration, suppress the immediate post-reset chime.
 
-**Behaviour details**
+**Behavior details**
 - **Running target is pour-based, not time-based.** It updates instantly on **Skip/Prev**.
 - **Zero-volume steps (Drawdown):** target **holds** at the last non-zero cumulative value.
 - **Auto-stop:** Timer stops at total duration; plays finish chime and shows celebration.


### PR DESCRIPTION
## Summary
- americanize behavior spelling in README
- stabilize chime callbacks and remove unused helper to satisfy eslint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d648c2014832e86d2035f26c14ff6