### PR TITLE
Highlight drawdown step

### DIFF
--- a/src/components/Brew.jsx
+++ b/src/components/Brew.jsx
@@ -243,7 +243,7 @@ export default function Brew({ recipe, onBack }) {
           const start = i === 0 ? 0 : cumEndMs[i - 1];
           const end = cumEndMs[i];
           const arrow = showWeightTarget ? cumPourTargets[i] : null;
-          const isActivePour = i === currentStepIdx && s.volume > 0;
+          const isActive = i === currentStepIdx;
           return (
             <Step
               key={i}
@@ -253,7 +253,7 @@ export default function Brew({ recipe, onBack }) {
               end={fmtClock(end)}
               arrow={arrow}
               showWeightTarget={showWeightTarget}
-              isActive={isActivePour}
+              isActive={isActive}
             />
           );
         })}


### PR DESCRIPTION
## Summary
- Treat drawdown as active by using step index alone
- Pass `isActive` flag to `Step` so non-pour steps highlight

## Testing
- `npm run lint`
- `npm test` *(fails: ReferenceError: expect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689d794a95b8832ea1d4214cd77a4edd