### PR TITLE
Enhance brew UI and lock inputs after start

### DIFF
--- a/src/components/Step.jsx
+++ b/src/components/Step.jsx
@@ -7,29 +7,40 @@ export default function Step({ step, idx, start, end, arrow, showWeightTarget, i
       className={[
         'relative rounded-xl border p-3 transition-colors',
         isActive
-          ? 'bg-emerald-500/10 border-emerald-400 shadow-[0_0_0_1px_rgba(16,185,129,0.25)]'
+          ? 'bg-[var(--color-accent)]/20 border-[var(--color-accent)] shadow-[0_0_0_1px_rgba(5,150,105,0.25)]'
           : 'bg-neutral-800/60 border-neutral-700'
       ].join(' ')}
       aria-current={isActive ? 'step' : undefined}
     >
-      {isActive && (
-        <span
-          className="coffee-steam absolute right-3 top-1/2 -translate-y-1/2"
-          aria-hidden="true"
-        >
-          ☕
-        </span>
-      )}
       <div className="flex items-center justify-between">
-        <div className="font-medium text-[var(--color-light-text)]">{step.label}</div>
-        <div className="text-[var(--color-light-muted)] text-sm">{step.volume} g • {step.durationSec}s</div>
+        <div
+          className={[
+            'font-medium',
+            isActive ? 'text-[var(--color-text)]' : 'text-[var(--color-light-text)]'
+          ].join(' ')}
+        >
+          {step.label}
+        </div>
+        <div
+          className={[
+            'text-sm',
+            isActive ? 'text-[var(--color-muted)]' : 'text-[var(--color-light-muted)]'
+          ].join(' ')}
+        >
+          {step.volume} g • {step.durationSec}s
+        </div>
       </div>
-      <div className="mt-1 flex items-center justify-between text-xs text-[var(--color-light-muted)]">
+      <div
+        className={[
+          'mt-1 flex items-center justify-between text-xs',
+          isActive ? 'text-[var(--color-muted)]' : 'text-[var(--color-light-muted)]'
+        ].join(' ')}
+      >
         <div>start {start}</div>
         <div>end {end}</div>
       </div>
       {showWeightTarget && (
-        <div className="mt-1 text-emerald-400 text-xs">→ {arrow} g</div>
+        <div className="mt-1 text-[var(--color-accent)] text-xs">→ {arrow} g</div>
       )}
     </div>
   );

--- a/test/step.test.jsx
+++ b/test/step.test.jsx
@@ -8,13 +8,14 @@ describe('Step', () => {
   afterEach(() => {
     cleanup();
   });
-  it('shows coffee when active', () => {
+  it('renders active step without icon', () => {
     render(<Step step={step} idx={0} start="0:00" end="0:30" arrow={10} showWeightTarget isActive />);
-    expect(screen.getByText('☕')).toBeInTheDocument();
+    expect(screen.queryByText('☕')).toBeNull();
+    expect(screen.getByText('→ 10 g')).toBeInTheDocument();
   });
 
-  it('hides coffee when inactive', () => {
+  it('renders inactive step', () => {
     render(<Step step={step} idx={0} start="0:00" end="0:30" arrow={10} showWeightTarget={false} isActive={false} />);
-    expect(screen.queryByText('☕')).toBeNull();
+    expect(screen.getByText('Pour')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Show cumulative pour target beside the main timer using the accent color and unified font
- Improve step styling: remove coffee icon, fix highlight readability, and use accent palette
- Lock coffee/ratio inputs once brewing begins and tuck recipe description behind a "See More Info" toggle

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e03663218832ea7da3d419cdca932