### PR TITLE
Improve accent color contrast

### DIFF
--- a/src/components/Step.jsx
+++ b/src/components/Step.jsx
@@ -7,7 +7,7 @@ export default function Step({ step, idx, start, end, arrow, showWeightTarget, i
       className={[
         'relative rounded-xl border p-3 transition-colors',
         isActive
-          ? 'bg-[var(--color-accent)]/20 border-[var(--color-accent)] shadow-[0_0_0_1px_rgba(5,150,105,0.25)]'
+          ? 'bg-[var(--color-accent)]/20 border-[var(--color-accent)] shadow-[0_0_0_1px_rgba(37,99,235,0.25)]'
           : 'bg-neutral-800/60 border-neutral-700'
       ].join(' ')}
       aria-current={isActive ? 'step' : undefined}

--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@
   --color-muted: #6b7280;
   --color-light-text: #f9fafb;
   --color-light-muted: #d1d5db;
-  --color-accent: #059669;
+  --color-accent: #2563eb;
 }
 
 body {


### PR DESCRIPTION
## Summary
- replace green accent tone with more readable blue

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e0817b06c832e9a13b9cf8512f978