### PR TITLE
Align coffee and ratio controls

### DIFF
--- a/src/components/Brew.jsx
+++ b/src/components/Brew.jsx
@@ -205,21 +205,89 @@ export default function Brew({ recipe, onBack }) {
             <div className="flex items-center justify-between">
               <label className="text-xs text-[var(--color-muted)]">Coffee (g)</label>
             </div>
-            <input type="range" min={10} max={40} step={1} value={coffeeG} onChange={e => setCoffeeG(clamp(parseInt(e.target.value,10),10,40))} className="h-12 w-full" disabled={inputsLocked} />
-            <div className="flex flex-col items-start mt-1">
-              <input type="number" inputMode="numeric" min={10} max={40} step={1} value={coffeeInput} onChange={e => { const v = e.target.value; setCoffeeInput(v); const n = parseInt(v,10); if (!Number.isNaN(n)) setCoffeeG(clamp(n,10,40)); }} onBlur={() => { const n = parseInt(coffeeInput,10); setCoffeeInput(Number.isNaN(n)? String(coffeeG): String(clamp(n,10,40))); }} className="w-20 h-10 rounded-lg px-2 bg-[var(--color-card-bg)] border border-[var(--color-card-border)] text-[var(--color-text)]" disabled={inputsLocked} />
-              <span className="text-sm text-[var(--color-text)] mt-1">{totalWater} g total</span>
+            <div className="grid grid-cols-[1fr_auto] items-center gap-2 mt-1">
+              <input
+                type="range"
+                min={10}
+                max={40}
+                step={1}
+                value={coffeeG}
+                onChange={e => setCoffeeG(clamp(parseInt(e.target.value, 10), 10, 40))}
+                className="h-10 w-full min-w-0"
+                disabled={inputsLocked}
+              />
+              <input
+                type="number"
+                inputMode="numeric"
+                min={10}
+                max={40}
+                step={1}
+                value={coffeeInput}
+                onChange={e => {
+                  const v = e.target.value;
+                  setCoffeeInput(v);
+                  const n = parseInt(v, 10);
+                  if (!Number.isNaN(n)) setCoffeeG(clamp(n, 10, 40));
+                }}
+                onBlur={() => {
+                  const n = parseInt(coffeeInput, 10);
+                  setCoffeeInput(Number.isNaN(n) ? String(coffeeG) : String(clamp(n, 10, 40)));
+                }}
+                className="w-20 h-10 rounded-lg px-2 bg-[var(--color-card-bg)] border border-[var(--color-card-border)] text-[var(--color-text)]"
+                disabled={inputsLocked}
+              />
             </div>
+            <span className="text-sm text-[var(--color-text)] mt-1">{totalWater} g total</span>
           </div>
 
           <div className="flex flex-col">
             <div className="flex items-center justify-between">
               <label className="text-xs text-[var(--color-muted)]">Ratio (1:water)</label>
-              <button type="button" onClick={() => { setRatio(DEFAULT_RATIO); setRatioInput(String(DEFAULT_RATIO)); }} className="text-xs px-2 py-1 rounded-lg border border-[var(--color-card-border)] bg-[var(--color-bg)] text-[var(--color-text)] disabled:opacity-50" aria-label="Reset ratio to default" disabled={inputsLocked}>Default</button>
+              <button
+                type="button"
+                onClick={() => { setRatio(DEFAULT_RATIO); setRatioInput(String(DEFAULT_RATIO)); }}
+                className="text-xs px-2 py-1 rounded-lg border border-[var(--color-card-border)] bg-[var(--color-bg)] text-[var(--color-text)] disabled:opacity-50"
+                aria-label="Reset ratio to default"
+                disabled={inputsLocked}
+              >
+                Default
+              </button>
             </div>
-            <input type="range" min={10} max={18} step={1} value={ratio} onChange={e => { const n = clamp(parseInt(e.target.value,10),10,18); setRatio(n); setRatioInput(String(n)); }} className="h-12 w-full" disabled={inputsLocked} />
-            <div className="mt-1">
-              <input type="number" inputMode="numeric" min={10} max={18} step={1} value={ratioInput} onChange={e => { const v = e.target.value; setRatioInput(v); const n = parseInt(v,10); if (!Number.isNaN(n)) setRatio(clamp(n,10,18)); }} onBlur={() => { const n = parseInt(ratioInput,10); setRatioInput(Number.isNaN(n)? String(ratio): String(clamp(n,10,18))); }} className="w-20 h-10 rounded-lg px-2 bg-[var(--color-card-bg)] border border-[var(--color-card-border)] text-[var(--color-text)]" disabled={inputsLocked} />
+            <div className="grid grid-cols-[1fr_auto] items-center gap-2 mt-1">
+              <input
+                type="range"
+                min={10}
+                max={18}
+                step={1}
+                value={ratio}
+                onChange={e => {
+                  const n = clamp(parseInt(e.target.value, 10), 10, 18);
+                  setRatio(n);
+                  setRatioInput(String(n));
+                }}
+                className="h-10 w-full min-w-0"
+                disabled={inputsLocked}
+              />
+              <input
+                type="number"
+                inputMode="numeric"
+                min={10}
+                max={18}
+                step={1}
+                value={ratioInput}
+                onChange={e => {
+                  const v = e.target.value;
+                  setRatioInput(v);
+                  const n = parseInt(v, 10);
+                  if (!Number.isNaN(n)) setRatio(clamp(n, 10, 18));
+                }}
+                onBlur={() => {
+                  const n = parseInt(ratioInput, 10);
+                  setRatioInput(Number.isNaN(n) ? String(ratio) : String(clamp(n, 10, 18)));
+                }}
+                className="w-20 h-10 rounded-lg px-2 bg-[var(--color-card-bg)] border border-[var(--color-card-border)] text-[var(--color-text)]"
+                disabled={inputsLocked}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Ensure coffee and ratio sliders and numeric inputs share a single aligned row
- Keep easy reset to default ratio

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8b1c21170832ea3fda5021ca794cf