### PR TITLE
feat: per-recipe default coffee-water ratios

### DIFF
--- a/src/components/Brew.jsx
+++ b/src/components/Brew.jsx
@@ -2,14 +2,14 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Step from './Step';
 
 export default function Brew({ recipe, onBack }) {
-  const DEFAULT_RATIO = 15;
+  const defaultRatio = recipe.defaultRatio ?? 15;
   const [coffeeG, setCoffeeG] = useState(20);
-  const [ratio, setRatio] = useState(DEFAULT_RATIO);
+  const [ratio, setRatio] = useState(defaultRatio);
   const [showWeightTarget, setShowWeightTarget] = useState(true);
   const [showInfo, setShowInfo] = useState(false);
   const waterTempC = recipe.defaultTemp;
   const [coffeeInput, setCoffeeInput] = useState(String(20));
-  const [ratioInput, setRatioInput] = useState(String(DEFAULT_RATIO));
+  const [ratioInput, setRatioInput] = useState(String(defaultRatio));
   const [isRunning, setIsRunning] = useState(false);
   const [elapsedMs, setElapsedMs] = useState(0);
   const [showCelebration, setShowCelebration] = useState(false);
@@ -67,9 +67,11 @@ export default function Brew({ recipe, onBack }) {
   useEffect(() => { setRatioInput(String(ratio)); }, [ratio]);
   useEffect(() => {
     hardReset(false);
+    setRatio(defaultRatio);
+    setRatioInput(String(defaultRatio));
     setShowInfo(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [recipe]);
+  }, [recipe, defaultRatio]);
 
   // derived step data
   const totalWater = useMemo(() => Math.round(coffeeG * ratio), [coffeeG, ratio]);
@@ -245,7 +247,7 @@ export default function Brew({ recipe, onBack }) {
               <label className="text-xs text-[var(--color-muted)]">Ratio (1:water)</label>
               <button
                 type="button"
-                onClick={() => { setRatio(DEFAULT_RATIO); setRatioInput(String(DEFAULT_RATIO)); }}
+                onClick={() => { setRatio(defaultRatio); setRatioInput(String(defaultRatio)); }}
                 className="text-xs px-2 py-1 rounded-lg border border-[var(--color-card-border)] bg-[var(--color-bg)] text-[var(--color-text)] disabled:opacity-50"
                 aria-label="Reset ratio to default"
                 disabled={inputsLocked}

--- a/src/recipes.js
+++ b/src/recipes.js
@@ -4,6 +4,7 @@ export const RECIPES = [
     name: "Matt Winton — 5-Pour",
     desc: "Five equal pours; gentle pace and even bed.",
     defaultTemp: 93,
+    defaultRatio: 15,
     buildSteps: (coffeeG, ratio) => {
       const total = Math.round(coffeeG * ratio);
       const per = Math.round(total / 5);
@@ -22,6 +23,7 @@ export const RECIPES = [
     name: "Tetsu Kasuya — 4:6",
     desc: "First 40% for taste (2 pours), last 60% for strength (3 pours).",
     defaultTemp: 93,
+    defaultRatio: 15,
     buildSteps: (coffeeG, ratio) => {
       const total = Math.round(coffeeG * ratio);
       const p1 = Math.round(total * (1 / 6)); // ~50g of 300g
@@ -44,6 +46,7 @@ export const RECIPES = [
     name: "Tetsu Kasuya — Switch",
     desc: "Two equal pours with a closed steep, then open to drain.",
     defaultTemp: 93,
+    defaultRatio: 16,
     buildSteps: (coffeeG, ratio) => {
       const total = Math.round(coffeeG * ratio);
       const p1 = Math.round(total / 2);
@@ -60,6 +63,7 @@ export const RECIPES = [
     name: "James Hoffmann — Bloom + 60/40",
     desc: "Bloom ~2× coffee for 45s, then 60/40 split.",
     defaultTemp: 100,
+    defaultRatio: 15,
     buildSteps: (coffeeG, ratio) => {
       const total = Math.round(coffeeG * ratio);
       const bloom = Math.round(coffeeG * 2);
@@ -78,6 +82,7 @@ export const RECIPES = [
     name: "James Hoffmann — 5-Pour (2019)",
     desc: "Bloom ~2× coffee, then 4 equal pours.",
     defaultTemp: 100,
+    defaultRatio: 15,
     buildSteps: (coffeeG, ratio) => {
       const total = Math.round(coffeeG * ratio);
       const bloom = Math.round(coffeeG * 2);

--- a/test/recipes.test.js
+++ b/test/recipes.test.js
@@ -23,4 +23,18 @@ describe('recipe builders', () => {
     const total = steps.reduce((a, s) => a + s.volume, 0);
     expect(total).toBe(Math.round(20 * 16));
   });
+
+  it('provides recipe-specific default ratios', () => {
+    const expected = {
+      winton5: 15,
+      kasuya46: 15,
+      kasuyaSwitch: 16,
+      hoffmann6040: 15,
+      hoffmann5: 15,
+    };
+    for (const [id, ratio] of Object.entries(expected)) {
+      const r = RECIPES.find(rcp => rcp.id === id);
+      expect(r.defaultRatio).toBe(ratio);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add `defaultRatio` to each recipe and set Hybrid Tetsu Kasuya to 1:16
- drive Brew ratio controls from each recipe's default ratio
- cover default ratios with tests

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af51c02394832e9defce5b16151d40